### PR TITLE
feat: add roles form & allocate role to profile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "client-only": "^0.0.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
-        "expo-backend-types": "^0.57.0-EXPO-377-Etapa-4-Paquete-02.7",
+        "expo-backend-types": "^0.59.0-EXPO-405-EB-Rutas-necesarias.9",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.474.0",
         "next": "15.1.4",
@@ -4600,9 +4600,9 @@
       }
     },
     "node_modules/expo-backend-types": {
-      "version": "0.57.0-EXPO-377-Etapa-4-Paquete-02.7",
-      "resolved": "https://registry.npmjs.org/expo-backend-types/-/expo-backend-types-0.57.0-EXPO-377-Etapa-4-Paquete-02.7.tgz",
-      "integrity": "sha512-kv9ImGlKpFccTGuFqG9BK+ckAKDPasJmeycl7qaGj2tBg0ug0VOvmqqTPka2cZvbg8RsC363nn+zE3bmbaI3aw==",
+      "version": "0.59.0-EXPO-405-EB-Rutas-necesarias.9",
+      "resolved": "https://registry.npmjs.org/expo-backend-types/-/expo-backend-types-0.59.0-EXPO-405-EB-Rutas-necesarias.9.tgz",
+      "integrity": "sha512-0sxXfinPebheU9XLLSpcZi+t4SLXV9b/jJCBkQV2eKnf8YcnQz02vL8lhkUQkqMA1OAw2pUh5SAs9vP2IrqPkg==",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "client-only": "^0.0.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
-    "expo-backend-types": "^0.57.0-EXPO-377-Etapa-4-Paquete-02.7",
+    "expo-backend-types": "^0.59.0-EXPO-405-EB-Rutas-necesarias.9",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.474.0",
     "next": "15.1.4",

--- a/src/app/(auth)/login/(layout)/choose-role/actions.ts
+++ b/src/app/(auth)/login/(layout)/choose-role/actions.ts
@@ -10,10 +10,12 @@ export type ChooseRoleActionState = {
   role?: string;
   name?: string;
   description?: string;
+  roles?: string[];
   errors?: {
     role?: string[];
     name?: string[];
     description?: string[];
+    roles?: string;
     general?: string;
   };
 };
@@ -24,13 +26,14 @@ export async function chooseRole(
 ): Promise<ChooseRoleActionState> {
   const me = await trpc.me.get();
   const role = formData.get('role') as string;
+  const roles = formData.getAll('roles[]') as string[];
 
   if (!me) {
     return {
       ...prevState,
       errors: {
         general:
-          'No se pudo encontrar el perfil, vuelva la verificar el telefono',
+          'No se pudo encontrar el perfil, vuelva a verificar el telefono',
       },
     };
   }
@@ -42,6 +45,29 @@ export async function chooseRole(
   };
 
   if (role === 'participant') {
+    if (roles.length === 0) {
+      return {
+        ...prevState,
+        errors: {
+          roles: 'Debe elegir al menos una opcion',
+        },
+      };
+    }
+
+    try {
+      await trpc.role.allocateParticipant({
+        roleIds: roles,
+        profileId: me.id,
+      });
+    } catch {
+      return {
+        ...rawData,
+        errors: {
+          general: 'Error al asignar el rol, vuelva a intentarlo',
+        },
+      };
+    }
+
     redirect('/login/questions/participant');
   } else if (role === 'producer') {
     const validatedData = createProductionSchema.safeParse(rawData);
@@ -57,6 +83,20 @@ export async function chooseRole(
     }
 
     await trpc.production.create(validatedData.data);
+
+    try {
+      await trpc.role.allocateProduction({
+        profileId: me.id,
+      });
+    } catch {
+      return {
+        ...rawData,
+        errors: {
+          general: 'Error al asignar el rol, vuelva a intentarlo',
+        },
+      };
+    }
+
     redirect('/login/questions/producer');
   }
 

--- a/src/app/(auth)/login/(layout)/choose-role/page.tsx
+++ b/src/app/(auth)/login/(layout)/choose-role/page.tsx
@@ -6,10 +6,15 @@ import { useActionState, useState } from 'react';
 import { chooseRole } from './actions';
 import { GoBack } from '@/components/go-back';
 import Image from 'next/image';
+import { RadioGroup } from '@/components/ui/radio-group';
+import { trpc } from '@/server/trpc/client';
+import clsx from 'clsx';
+import { Checkbox } from '@/components/ui/checkbox';
 
 export default function ChooseRolePage() {
   const [selectedRole, setSelectedRole] = useState<string>('');
   const [state, formAction, isPending] = useActionState(chooseRole, {});
+  const { data } = trpc.role.getAll.useQuery();
 
   return (
     <>
@@ -34,6 +39,49 @@ export default function ChooseRolePage() {
               quienes tienen un rol activo en lo que pasa en el show.
             </p>
           </article>
+          {data && selectedRole === 'participant' && (
+            <div className='space-y-8 animate-in slide-in-from-top-2 duration-200'>
+              <div className='space-y-0'>
+                <Label variant={'miExpoCard'} htmlFor='name'>
+                  Selecciona tu/s rol/es
+                  <span className='text-red-600 font-bold'>*</span>
+                </Label>
+                <RadioGroup name='roles' className='gap-0'>
+                  {data.map((role, index) => {
+                    return (
+                      <div
+                        key={index}
+                        className={clsx(
+                          'px-4 py-2 border-x-[1px] border-miExpo-gray flex items-center gap-2 ',
+                          {
+                            'rounded-tr-lg border-[1px] border-b-0 pt-4':
+                              index === 0,
+                            'rounded-b-lg border-b-[1px] pb-4':
+                              index === data.length - 1,
+                          },
+                        )}
+                      >
+                        <Checkbox
+                          className='transition-colors'
+                          name='roles[]'
+                          value={role.id}
+                          id={role.id}
+                        />
+
+                        <label htmlFor={role.id}>{role.name}</label>
+                      </div>
+                    );
+                  })}
+                </RadioGroup>
+                {state.errors?.roles && (
+                  <p className='text-sm font-bold text-red-500'>
+                    {state.errors.roles}
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+
           <article
             onClick={() => setSelectedRole('producer')}
             className={`flex flex-col items-center justify-between rounded-xl border-[1px] p-4 cursor-pointer transition-colors text-white border-miExpo-gray ${
@@ -54,6 +102,7 @@ export default function ChooseRolePage() {
               <div className='space-y-0'>
                 <Label variant={'miExpoCard'} htmlFor='name'>
                   Nombre de la producción
+                  <span className='text-red-600 font-bold'>*</span>
                 </Label>
                 <Input
                   variant={'MiExpoCard'}
@@ -70,6 +119,7 @@ export default function ChooseRolePage() {
               <div className='space-y-0'>
                 <Label variant={'miExpoCard'} htmlFor='description'>
                   Descripción de la producción
+                  <span className='text-red-600 font-bold'>*</span>
                 </Label>
                 <textarea
                   className='min-h-20 max-h-48 flex w-full border-input bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm file:border-0 file:bg-transparent text-base transition-colors border-[1px] rounded-lg rounded-tl-none border-miExpo-gray px-4 py-2'
@@ -85,7 +135,7 @@ export default function ChooseRolePage() {
               </div>
             </div>
           )}
-          {state.errors?.description && (
+          {state.errors?.general && (
             <p className='text-sm font-bold text-red-500'>
               {state.errors.general}
             </p>

--- a/src/server/routers/app.ts
+++ b/src/server/routers/app.ts
@@ -6,6 +6,7 @@ import { router } from '@/server/trpc';
 import { productionRouter } from '@/server/routers/production';
 import { productionAffiliationRequestRouter } from '@/server/routers/production-affiliation-request';
 import { dynamicFormRouter } from '@/server/routers/dynamic-form';
+import { roleRouter } from './role';
 
 export const appRouter = router({
   otp: otpRouter,
@@ -15,6 +16,7 @@ export const appRouter = router({
   production: productionRouter,
   productionAfilliationRequest: productionAffiliationRequestRouter,
   dynamicForm: dynamicFormRouter,
+  role: roleRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/src/server/routers/role.ts
+++ b/src/server/routers/role.ts
@@ -1,0 +1,44 @@
+import { handleError, protectedProcedure, router } from '@/server/trpc';
+import {
+  allocateParticipantRoleSchema,
+  allocateProductionRoleSchema,
+} from 'expo-backend-types';
+
+export const roleRouter = router({
+  getAll: protectedProcedure.query(async ({ ctx }) => {
+    const { data } = await ctx.fetch.GET('/role/all');
+    return data;
+  }),
+  allocateParticipant: protectedProcedure
+    .input(allocateParticipantRoleSchema)
+    .mutation(async ({ input, ctx }) => {
+      const { data, error } = await ctx.fetch.POST(
+        '/role/allocate-participant',
+        {
+          body: input,
+        },
+      );
+
+      if (error) handleError(error);
+
+      return data;
+    }),
+  allocateProduction: protectedProcedure
+    .input(allocateProductionRoleSchema)
+    .mutation(async ({ input, ctx }) => {
+      const { data, error } = await ctx.fetch.POST(
+        '/role/allocate-production/{id}',
+        {
+          params: {
+            path: {
+              id: input.profileId,
+            },
+          },
+        },
+      );
+
+      if (error) handleError(error);
+
+      return data;
+    }),
+});


### PR DESCRIPTION
En esta PR agrego un checkbox de roles al formulario de eleccion de rol (`'/choose-role'`). Si el usuario elige ser participante se despliega una lista con todos los roles posibles. Si el usuario elige ser productor, luego de llenar el formulario correctamente se le agrega el rol productor

Agrego el `roleRouter` como router para todos los endpoints necesarios.

Validaciones:
Si el usuario no elige ningun rol
![form-roles](https://github.com/user-attachments/assets/b5fbf6e1-e47a-4d02-8892-ebff373a6a41)

Si el usuario vuelve a enviar el formulario (volviendo atras) y eligiendo otros roles o ser productor, se le remueven todos los roles y se agregan los últimos enviados.